### PR TITLE
Add a list of related repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,15 @@ accounting and billign services (a private repository and container image)
 [squonk2-data-manager-job-operator] : The Squonk2 Job operator
 (launches Jobs)
 
-[squonk2-fragmenstein] : Squonk2 JOb defintions used by the Fragalysi Stack
+[squonk2-fragmenstein] : Squonk2 Job defintions used by the Fragalysi Stack
 
 >   Numerous other respositories exist for Job execution etc.
     For inmformatics Matters any respository
     that has the topic tag `squonk2` or `squonk2-jobs` might be relevant.
+
+[docker-volume-replicator] : Replicates volumes (used for media)
+
+[bandr] : PostgreSQL backup and recovery container images
 
 **Fragmentation**
 
@@ -112,6 +116,8 @@ typically kubernetes or slurm: -
 
 ---
 
+[bandr]: https://github.com/InformaticsMatters/bandr
+[docker-volume-replicator]: https://github.com/InformaticsMatters/docker-volume-replicator
 [squonk2-fragmenstein]: https://github.com/InformaticsMatters/squonk2-fragmenstein
 [squonk2-data-manager-job-operator]: https://github.com/InformaticsMatters/squonk2-data-manager-job-operator
 [squonk2-data-manager-jupyter-operator]: https://github.com/InformaticsMatters/squonk2-data-manager-jupyter-operator

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ The Fragalysis Stack you find running in Kubernetes relies on a number of relate
 (and diverse) repositories. We've tried to capture references to all of them
 below, in no particular order: -
 
----
-
 **xchem respositories**
 
 [fragalysis-package] : Logic that allows connection to the neo4j graph
@@ -75,8 +73,6 @@ as an interface to ISPyB, yielding Target Access Strings based on username
 
 [docker-neo4j] : Custom neo4j image providing built-in S3 bucket bulk-loading
 
----
-
 **3rd-party respositories (Informatics Matters)**
 
 There are also a number of 3rd-party repositories that provide facilities for
@@ -101,8 +97,6 @@ accounting and billign services (a private repository and container image)
 >   Numerous other respositories exist for Job execution etc.
     For inmformatics Matters any respository
     that has the topic tag `squonk2` or `squonk2-jobs` might be relevant.
-
----
 
 **Fragmentation**
 

--- a/README.md
+++ b/README.md
@@ -39,20 +39,115 @@ Then, to build the HTML documentation, run the following command: -
 
 The resulting `index.html` will be in the `docs/build/` directory.
 
-## See also
+## Related repositories
 The Fragalysis Stack you find running in Kubernetes relies on a number of related
 (and diverse) repositories. We've tried to capture references to all of them
-below: -
-
-| Repository | Description |
-| --- | --- |
-| fragalysis-package | Logic that allows connection to the neo4j graph |
-| ragalysis-backend | Django/REST Framework application |
-| fragalysis-frontend | Django application (frontend) |
-| fragalysis-stack | The respository that combines the backed and frontend to create the container image |
+below, in no particular order: -
 
 ---
 
+**xchem respositories**
+
+[fragalysis-package]
+: Logic that allows connection to the neo4j graph
+
+[fragalysis-backend]
+: Django/REST Framework application
+
+[fragalysis-frontend]
+: Django visual application (frontend)
+
+[fragalysis-stack]
+: The build logic that combines the backed and frontend to create the container image
+
+[fragalysis-api]
+: Command-line API utilities
+
+[fragalysis-keycloak]
+: A specialised build of keycloak to provide a custom login theme
+
+[fragalysis-ispyb-target-access-authenticator]
+: Code for the container image that acts as an interface to ISPyB, yielding Target Access Strings based on username
+
+[fragalysis-mock-target-access-authenticator]
+: A "mock" ISPyB authenticator (providing results based on a config file)
+
+[fragalysis-stack-kubernetes]
+: Ansible playbooks for application deployment and management
+
+[fragalysis-stack-behaviour-tests]
+: Basic gherkin-based behaviour tests for the stack API
+
+[xchem-align]
+: Tools to generate input data for Fragalysis
+
+[docker-neo4j]
+: Custom neo4j image providing built-in S3 bucket bulk-loading
+
+---
+
+**3rd-party respositories**
+
+There are also a number of 3rd-party repositories that provide facilities for
+the Fragalysis Stack application: -
+
+[squonk2-data-manager] (Informatics Matters/PRIVATE)
+: The Squonk2 Data Manager (a private repository and container image)
+
+[squonk2-account-server] (Informatics Matters/PRIVATE)
+: The Squonk2 Account Server providing accounting and billign services (a private repository and container image)
+
+[squonk2-data-manager-ui] (Informatics Matters)
+: The Squonk2 UI
+
+[squonk2-data-manager-jupyter-operator] (Informatics Matters)
+: The Squonk2 Jupyter Notebook operator (launches notebooks)
+
+[squonk2-data-manager-job-operator] (Informatics Matters)
+: The Squonk2 Job operator (launches Jobs)
+
+[squonk2-fragmenstein] (Informatics Matters)
+: Squonk2 JOb defintions used by the Fragalysi Stack
+
+>   Numerous other respositories exist for Job execution etc.
+    For inmformatics Matters any respository
+    that has the topic tag `squonk2` or `squonk2-jobs` might be relevant.
+
+---
+
+**Fragmentation**
+
+There is also the fragmentation logic that is used to compile the underlying neo4j
+database CSV files. These processes rely on access to substabntial computing resources -
+typically kubernetes or slurm: -
+
+[fragmentor] (Informatics Matters)
+: Standardisation, fragmentation and combination graph logic (and playbooks)
+
+[fragmentor-k8s-orchestration] (Informatics Matters)
+: Ansible playbooks for the Kubernetes-based execution of fragmentor Playbooks
+
+---
+
+[squonk2-fragmenstein]: https://github.com/InformaticsMatters/squonk2-fragmenstein
+[squonk2-data-manager-job-operator]: https://github.com/InformaticsMatters/squonk2-data-manager-job-operator
+[squonk2-data-manager-jupyter-operator]: https://github.com/InformaticsMatters/squonk2-data-manager-jupyter-operator
+[squonk2-data-manager-ui]: https://github.com/InformaticsMatters/squonk2-data-manager-ui
+[squonk2-account-server]: https://gitlab.com/informaticsmatters/squonk2-account-server
+[squonk2-data-manager]: https://gitlab.com/informaticsmatters/squonk2-data-manager
+[fragmentor-k8s-orchestration]: https://github.com/InformaticsMatters/fragmentor-k8s-orchestration
+[fragmentor]: https://github.com/InformaticsMatters/fragmentor
+[docker-neo4j]: https://github.com/xchem/docker-neo4j
+[fragalysis-stack-behaviour-tests]: https://github.com/xchem/fragalysis-stack-behaviour-tests
+[fragalysis-mock-target-access-authenticator]: https://github.com/xchem/fragalysis-mock-target-access-authenticator
+[fragalysis-stack-kubernetes]: https://github.com/xchem/fragalysis-stack-kubernetes
+[fragalysis-ispyb-target-access-authenticator]: https://github.com/xchem/fragalysis-ispyb-target-access-authenticator
+[fragalysis-api]: https://github.com/xchem/fragalysis-api
+[fragalysis-backend]: https://github.com/xchem/fragalysis-backend
+[fragalysis-frontend]: https://github.com/xchem/fragalysis-frontend
+[fragalysis-keycloak]: https://github.com/xchem/fragalysis-keycloak
 [fragalysis-package]: https://github.com/xchem/fragalysis-package
+[fragalysis-stack]: https://github.com/xchem/fragalysis-stack
 [readthedocs]: https://app.readthedocs.org/dashboard/
 [sphinx]: https://www.sphinx-doc.org/en/master
+[xchem-align]: https://github.com/xchem/xchem-align

--- a/README.md
+++ b/README.md
@@ -48,66 +48,55 @@ below, in no particular order: -
 
 **xchem respositories**
 
-[fragalysis-package]
-: Logic that allows connection to the neo4j graph
+[fragalysis-package] : Logic that allows connection to the neo4j graph
 
-[fragalysis-backend]
-: Django/REST Framework application
+[fragalysis-backend] : Django/REST Framework application
 
-[fragalysis-frontend]
-: Django visual application (frontend)
+[fragalysis-frontend] : Django visual application (frontend)
 
-[fragalysis-stack]
-: The build logic that combines the backed and frontend to create the container image
+[fragalysis-stack] : The build logic that combines the backed and frontend
+to create the container image
 
-[fragalysis-api]
-: Command-line API utilities
+[fragalysis-api] : Command-line API utilities
 
-[fragalysis-keycloak]
-: A specialised build of keycloak to provide a custom login theme
+[fragalysis-keycloak] : A specialised build of keycloak to provide a custom login theme
 
-[fragalysis-ispyb-target-access-authenticator]
-: Code for the container image that acts as an interface to ISPyB, yielding Target Access Strings based on username
+[fragalysis-ispyb-target-access-authenticator] : Code for the container image that acts
+as an interface to ISPyB, yielding Target Access Strings based on username
 
-[fragalysis-mock-target-access-authenticator]
-: A "mock" ISPyB authenticator (providing results based on a config file)
+[fragalysis-mock-target-access-authenticator] : A "mock" ISPyB authenticator
+(providing results based on a config file)
 
-[fragalysis-stack-kubernetes]
-: Ansible playbooks for application deployment and management
+[fragalysis-stack-kubernetes] : Ansible playbooks for application deployment and management
 
-[fragalysis-stack-behaviour-tests]
-: Basic gherkin-based behaviour tests for the stack API
+[fragalysis-stack-behaviour-tests] : Basic gherkin-based behaviour tests for the stack API
 
-[xchem-align]
-: Tools to generate input data for Fragalysis
+[xchem-align] : Tools to generate input data for Fragalysis
 
-[docker-neo4j]
-: Custom neo4j image providing built-in S3 bucket bulk-loading
+[docker-neo4j] : Custom neo4j image providing built-in S3 bucket bulk-loading
 
 ---
 
-**3rd-party respositories**
+**3rd-party respositories (Informatics Matters)**
 
 There are also a number of 3rd-party repositories that provide facilities for
 the Fragalysis Stack application: -
 
-[squonk2-data-manager] (Informatics Matters/PRIVATE)
-: The Squonk2 Data Manager (a private repository and container image)
+[squonk2-data-manager] (`PRIVATE`) : The Squonk2 Data Manager
+(a private repository and container image)
 
-[squonk2-account-server] (Informatics Matters/PRIVATE)
-: The Squonk2 Account Server providing accounting and billign services (a private repository and container image)
+[squonk2-account-server] (`PRIVATE`) : The Squonk2 Account Server providing
+accounting and billign services (a private repository and container image)
 
-[squonk2-data-manager-ui] (Informatics Matters)
-: The Squonk2 UI
+[squonk2-data-manager-ui] : The Squonk2 UI
 
-[squonk2-data-manager-jupyter-operator] (Informatics Matters)
-: The Squonk2 Jupyter Notebook operator (launches notebooks)
+[squonk2-data-manager-jupyter-operator] : The Squonk2 Jupyter Notebook operator
+(launches notebooks)
 
-[squonk2-data-manager-job-operator] (Informatics Matters)
-: The Squonk2 Job operator (launches Jobs)
+[squonk2-data-manager-job-operator] : The Squonk2 Job operator
+(launches Jobs)
 
-[squonk2-fragmenstein] (Informatics Matters)
-: Squonk2 JOb defintions used by the Fragalysi Stack
+[squonk2-fragmenstein] : Squonk2 JOb defintions used by the Fragalysi Stack
 
 >   Numerous other respositories exist for Job execution etc.
     For inmformatics Matters any respository

--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ Then, to build the HTML documentation, run the following command: -
 
 The resulting `index.html` will be in the `docs/build/` directory.
 
+## See also
+The Fragalysis Stack you find running in Kubernetes relies on a number of related
+(and diverse) repositories. We've tried to capture references to all of them
+below: -
+
+| Repository | Description |
+| --- | --- |
+| fragalysis-package | Logic that allows connection to the neo4j graph |
+| ragalysis-backend | Django/REST Framework application |
+| fragalysis-frontend | Django application (frontend) |
+| fragalysis-stack | The respository that combines the backed and frontend to create the container image |
+
 ---
 
 [fragalysis-package]: https://github.com/xchem/fragalysis-package


### PR DESCRIPTION
Sadly Markdown (and GitHub's version) is a rubbish at complex formatting (Markdown doesn't strictly have complex formatting anyway I guess). Nevertheless this change adds a number of repos and links to the in a **Related repositories** section.

I'm not suer of there are other repositories required ... like https://github.com/xchem/ligand_neighbourhood_alignment?