### PR TITLE
Now able to debug underlying requests

### DIFF
--- a/fragalysis/requests/download.py
+++ b/fragalysis/requests/download.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from json import JSONDecodeError
 from urllib.parse import urljoin
 
-from .session import _session
+from .session import _session, debug_requests_on
 from .urls import PROJECTS_URL, TARGETS_URL, DOWNLOAD_URL, TARGET_EXPERIMENT_UPLOADS_URL
 
 def target_list(
@@ -78,6 +78,7 @@ def download_target(
     extract: bool = True,
     debug: bool = False,
     iteration: int = 1,
+    debug_requests: bool = False
 ) -> None:
     """Request a target download from a Fragalysis deployment
 
@@ -101,6 +102,7 @@ def download_target(
     :param extract: Extract the downloaded zip / tar archive?
     :param debug: Add print debug displaying the change in download status text
     :param iteration: A number used to distinguish output messages (important when downloading concurrent targets)
+    :param debug_requests: True to set underlying HTTP request logging to DEBUG
     """
 
     payload = {
@@ -128,6 +130,9 @@ def download_target(
     if not destination.exists():
         mrich.error("Download destination does not exist:", destination)
         return None
+
+    if debug_requests:
+        debug_requests_on()
 
     with _session(stack, token) as session:
 

--- a/fragalysis/requests/session.py
+++ b/fragalysis/requests/session.py
@@ -1,18 +1,29 @@
+import logging
+from http.client import HTTPConnection
 import requests
 from urllib.parse import urljoin
-from pathlib import Path
+
 from .urls import STACKS, LANDING_PAGE_URL
 
 USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 
+def debug_requests_on(context_id: int = 1):
+    """Switches requests module logging on"""
+    HTTPConnection.debuglevel = 1
+
+    logging.basicConfig(
+        format=f"[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] # [{context_id}] %(message)s",
+        datefmt="%d/%b/%Y %H:%M:%S",
+    )
+    logging.getLogger().setLevel(logging.DEBUG)
+    requests_log = logging.getLogger("requests.packages.urllib3")
+    requests_log.setLevel(logging.DEBUG)
+    requests_log.propagate = True
+
 
 def _session(stack: str = "production", token: str | None = None):
 
-    if stack in STACKS:
-        url_root = STACKS[stack]
-    else:
-        url_root = stack
-
+    url_root = STACKS[stack] if stack in STACKS else stack
     landing_page_url = urljoin(url_root, LANDING_PAGE_URL)
 
     session = requests.Session()
@@ -27,12 +38,9 @@ def _session(stack: str = "production", token: str | None = None):
     )
 
     response = session.get(landing_page_url)  # sets csrftoken
-
     assert response.ok
 
-    # set manually if still missing
-    csrftoken = session.cookies.get("csrftoken", None)
-    if csrftoken:
+    if csrftoken := session.cookies.get("csrftoken", None):
         session.headers.update(
             {
                 "X-CSRFToken": csrftoken,

--- a/fragalysis/requests/urls.py
+++ b/fragalysis/requests/urls.py
@@ -1,9 +1,6 @@
-# fragalysis
-
 STACKS = {
     "staging": "https://fragalysis.xchem.diamond.ac.uk",
     "production": "https://fragalysis.diamond.ac.uk",
-    "matej-dev": "https://fragalysis-matej-default.xchem-dev.diamond.ac.uk",
 }
 
 LOGIN_URL = "/accounts/login/"


### PR DESCRIPTION
- Download now offers a debug_requests parameter (default False)
- When set this enables the underlying DEBUG log of the urllib3 module
- Also removes the deprecated developer stack URL